### PR TITLE
Bug fixes

### DIFF
--- a/webapp/src/components/Body/BodyModules.js
+++ b/webapp/src/components/Body/BodyModules.js
@@ -106,7 +106,7 @@ export const ModelSelect = () => {
         label="Model"
         onChange={(e) => {
           let newConfig = { ...config };
-          newConfig[selected] = { model: e.target.value };
+          newConfig[selected] = { model: e.target.value, "param": {}};
           dispatch(setConfig(newConfig));
         }}
       >

--- a/webapp/src/components/Header/Header.js
+++ b/webapp/src/components/Header/Header.js
@@ -22,6 +22,23 @@ const downloadJson = (config) => {
   return href;
 };
 
+// Turn numbers in config file (currently strings) into number types
+const parseNums = (config_obj) => {
+  // Use new config b/c config_obj is read-only
+  let string = JSON.stringify(config_obj);
+  let config = JSON.parse(string);
+
+  for (const step in config) {
+    for (const param in config[step]["param"] ) {
+      let value = config[step]["param"][param];
+      if (!isNaN(value)) {
+        config[step]["param"][param] = Number(value);
+      }
+    }
+  }
+  return config;
+}
+
 const Header = (props) => {
   const config = useSelector((state) => state.config.value);
   const [openExport, setOpenExport] = useState(false);
@@ -38,7 +55,7 @@ const Header = (props) => {
       <Button
         variant="contained"
         onClick={() => {
-          console.log(JSON.stringify(config));
+          console.log(JSON.stringify(parseNums(config)));
           // alert("Config has been printed into the console.");
           setOpenExport(true);
         }}
@@ -76,7 +93,7 @@ const Header = (props) => {
               variant="contained"
               className={styles.ModalButton}
               onClick={() => {
-                navigator.clipboard.writeText(JSON.stringify(config));
+                navigator.clipboard.writeText(JSON.stringify(parseNums(config)));
                 setOpenAlert(true);
               }}
             >
@@ -90,7 +107,7 @@ const Header = (props) => {
                 setOpenAlert(true);
               }}
             >
-              <a href={downloadJson(config)} download="config.json">
+              <a href={downloadJson(parseNums(config))} download="config.json">
                 Download JSON File
               </a>
             </Button>


### PR DESCRIPTION
- add empty param object to every model (FAVITES-Lite requires it to be there even if there are no params)
- convert strings to numbers (removing quotations) when user saves config (tried to directly change the e.target.value in the param selection but that kept running into issues with entering in numbers)